### PR TITLE
Bootstrap Cargo project structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tiny-talk"
+version = "0.1.0"
+edition = "2021"
+description = "A tiny Smalltalk-like language interpreter"
+license = "MIT"
+
+[dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,19 @@
+//! tiny-talk: A Smalltalk-like language interpreter
+//!
+//! This crate provides a minimal interpreter for a language inspired by Smalltalk,
+//! exploring message-passing and object-oriented programming concepts.
+
+/// Returns the version string for the interpreter.
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version() {
+        assert_eq!(version(), "0.1.0");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,6 @@
+use tiny_talk::version;
+
+fn main() {
+    println!("tiny-talk v{}", version());
+    println!("A Smalltalk-like language interpreter");
+}


### PR DESCRIPTION
This PR bootstraps the basic Cargo project structure for tiny-talk.

## Changes
- **Cargo.toml**: Package manifest with metadata (name, version, edition, description, license)
- **src/lib.rs**: Library entry point with a `version()` function and basic test
- **src/main.rs**: Binary entry point that prints the version and description

## Structure
The project follows standard Rust conventions with separate library (`lib.rs`) and binary (`main.rs`) targets. This allows the interpreter logic to be developed as a library while providing a CLI entry point.

## Note
I was unable to run `cargo build` or `cargo test` locally because Rust/Cargo is not installed in my environment. The code follows standard Rust conventions and should build correctly, but I recommend verifying the build in CI or locally.

Closes #4

---
@tangent-vector Please @-mention me in any review comments so I receive notifications to act on your feedback.