### PR TITLE
Fix formatting and clippy warnings for clean CI

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -87,13 +87,15 @@ use std::io::Write;
 ///
 /// Severity determines how the diagnostic is displayed and whether it
 /// prevents further processing.
+///
+/// Ordering: Note < Warning < Error (errors are most severe).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Severity {
-    /// An error that prevents successful completion.
+    /// Additional context or information.
     ///
-    /// Errors indicate problems that must be fixed before the program can run.
-    /// Examples: syntax errors, undefined variables, type mismatches.
-    Error,
+    /// Notes are attached to other diagnostics to provide more detail.
+    /// They're not standalone issues. Example: "see also: definition here"
+    Note,
 
     /// A warning about potentially problematic code.
     ///
@@ -101,11 +103,11 @@ pub enum Severity {
     /// as intended. Examples: unused variables, deprecated features.
     Warning,
 
-    /// Additional context or information.
+    /// An error that prevents successful completion.
     ///
-    /// Notes are attached to other diagnostics to provide more detail.
-    /// They're not standalone issues. Example: "see also: definition here"
-    Note,
+    /// Errors indicate problems that must be fixed before the program can run.
+    /// Examples: syntax errors, undefined variables, type mismatches.
+    Error,
 }
 
 impl Severity {
@@ -450,9 +452,9 @@ impl DiagnosticRenderer {
         // ANSI color codes
         let (color_start, color_end) = if self.use_colors {
             match diagnostic.severity() {
-                Severity::Error => ("\x1b[1;31m", "\x1b[0m"),   // Bold red
+                Severity::Error => ("\x1b[1;31m", "\x1b[0m"), // Bold red
                 Severity::Warning => ("\x1b[1;33m", "\x1b[0m"), // Bold yellow
-                Severity::Note => ("\x1b[1;36m", "\x1b[0m"),    // Bold cyan
+                Severity::Note => ("\x1b[1;36m", "\x1b[0m"),  // Bold cyan
             }
         } else {
             ("", "")
@@ -533,11 +535,14 @@ impl DiagnosticRenderer {
                 let span_len = span.len() as usize;
 
                 // Clamp span length to not exceed line length
-                let underline_len = span_len.min(line_text.len().saturating_sub(col_offset)).max(1);
+                let underline_len = span_len
+                    .min(line_text.len().saturating_sub(col_offset))
+                    .max(1);
 
                 // Choose underline character based on primary/secondary
                 let underline_char = if label.is_primary() { '^' } else { '-' };
-                let underline: String = std::iter::repeat(underline_char).take(underline_len).collect();
+                let underline: String =
+                    std::iter::repeat_n(underline_char, underline_len).collect();
 
                 // Print underline with message
                 writeln!(
@@ -722,8 +727,7 @@ mod tests {
         // Span on line 2, "line2" starts at offset 6
         let span = Span::new(id, 6, 5);
 
-        let diag = Diagnostic::error("error on line 2")
-            .with_label(Label::primary(span, "here"));
+        let diag = Diagnostic::error("error on line 2").with_label(Label::primary(span, "here"));
 
         let renderer = DiagnosticRenderer::new();
         let mut output = Vec::new();
@@ -741,8 +745,7 @@ mod tests {
         let id = sources.add_file("test.tt", "foo bar baz");
         let span = Span::new(id, 4, 3); // "bar"
 
-        let diag = Diagnostic::note("see also")
-            .with_label(Label::secondary(span, "defined here"));
+        let diag = Diagnostic::note("see also").with_label(Label::secondary(span, "defined here"));
 
         let renderer = DiagnosticRenderer::new();
         let mut output = Vec::new();
@@ -759,8 +762,8 @@ mod tests {
         let sources = SourceManager::new();
         let span = Span::synthetic();
 
-        let diag = Diagnostic::error("internal error")
-            .with_label(Label::primary(span, "generated code"));
+        let diag =
+            Diagnostic::error("internal error").with_label(Label::primary(span, "generated code"));
 
         let renderer = DiagnosticRenderer::new();
         let mut output = Vec::new();

--- a/src/lexeme.rs
+++ b/src/lexeme.rs
@@ -396,7 +396,7 @@ mod tests {
         assert!(TokenKind::Keyword("at:".into()).is_keyword());
         assert!(TokenKind::BinarySelector("+".into()).is_binary_selector());
         assert!(TokenKind::Integer(42).is_literal());
-        assert!(TokenKind::Float(3.14).is_literal());
+        assert!(TokenKind::Float(1.5).is_literal());
         assert!(TokenKind::String("hello".into()).is_literal());
         assert!(TokenKind::Symbol("sym".into()).is_literal());
         assert!(TokenKind::Character('a').is_literal());
@@ -417,7 +417,10 @@ mod tests {
 
     #[test]
     fn test_token_kind_description() {
-        assert_eq!(TokenKind::Identifier("x".into()).description(), "identifier");
+        assert_eq!(
+            TokenKind::Identifier("x".into()).description(),
+            "identifier"
+        );
         assert_eq!(TokenKind::LeftParen.description(), "'('");
         assert_eq!(TokenKind::Assign.description(), "':='");
         assert_eq!(TokenKind::Eof.description(), "end of file");
@@ -438,4 +441,3 @@ mod tests {
         assert_eq!(token.kind, TokenKind::Eof);
     }
 }
-

--- a/src/source.rs
+++ b/src/source.rs
@@ -68,7 +68,7 @@
 //! content—file IDs can be registered before content is loaded, with the actual text
 //! fetched on demand.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // ============================================================================
 // Source Identifiers
@@ -264,7 +264,7 @@ impl SourceFile {
         };
         let line_start = self.line_starts[line_index];
         LineCol {
-            line: (line_index + 1) as u32, // 1-based
+            line: (line_index + 1) as u32,     // 1-based
             column: (offset - line_start) + 1, // 1-based
         }
     }
@@ -489,11 +489,11 @@ mod tests {
     fn test_line_col_single_line() {
         let mut manager = SourceManager::new();
         let id = manager.add_file("test.tt", "hello world");
-        
+
         // Start of file
         let pos = manager.line_col(id, 0);
         assert_eq!(pos, LineCol { line: 1, column: 1 });
-        
+
         // Middle of line
         let pos = manager.line_col(id, 6);
         assert_eq!(pos, LineCol { line: 1, column: 7 });
@@ -505,19 +505,19 @@ mod tests {
         // "line1\nline2\nline3"
         // Offsets: l=0, i=1, n=2, e=3, 1=4, \n=5, l=6, i=7, n=8, e=9, 2=10, \n=11, l=12, ...
         let id = manager.add_file("test.tt", "line1\nline2\nline3");
-        
+
         // Start of line 1
         let pos = manager.line_col(id, 0);
         assert_eq!(pos, LineCol { line: 1, column: 1 });
-        
+
         // End of line 1 (the newline character)
         let pos = manager.line_col(id, 5);
         assert_eq!(pos, LineCol { line: 1, column: 6 });
-        
+
         // Start of line 2
         let pos = manager.line_col(id, 6);
         assert_eq!(pos, LineCol { line: 2, column: 1 });
-        
+
         // Start of line 3
         let pos = manager.line_col(id, 12);
         assert_eq!(pos, LineCol { line: 3, column: 1 });
@@ -527,7 +527,7 @@ mod tests {
     fn test_line_text() {
         let mut manager = SourceManager::new();
         let id = manager.add_file("test.tt", "line1\nline2\nline3");
-        
+
         assert_eq!(manager.line_text(id, 1), Some("line1"));
         assert_eq!(manager.line_text(id, 2), Some("line2"));
         assert_eq!(manager.line_text(id, 3), Some("line3"));
@@ -538,13 +538,13 @@ mod tests {
     #[test]
     fn test_line_count() {
         let mut manager = SourceManager::new();
-        
+
         let id1 = manager.add_file("single.tt", "hello");
         assert_eq!(manager.line_count(id1), 1);
-        
+
         let id2 = manager.add_file("multi.tt", "a\nb\nc");
         assert_eq!(manager.line_count(id2), 3);
-        
+
         let id3 = manager.add_file("trailing.tt", "a\nb\n");
         assert_eq!(manager.line_count(id3), 3); // Empty line after trailing newline
     }
@@ -563,10 +563,10 @@ mod tests {
         let id = manager.add_file("test.tt", "line1\nline2\nline3");
         // Span covering "line2" (bytes 6-11)
         let span = Span::new(id, 6, 5);
-        
+
         let start = manager.span_start_line_col(span);
         assert_eq!(start, LineCol { line: 2, column: 1 });
-        
+
         let end = manager.span_end_line_col(span);
         assert_eq!(end, LineCol { line: 2, column: 6 });
     }


### PR DESCRIPTION
This PR fixes the CI failures by addressing formatting and clippy warnings.

## Changes

### Formatting (`cargo fmt`)
- Applied rustfmt formatting across all source files
- Fixed trailing whitespace in test functions
- Adjusted line length for long method chains

### Clippy warnings
1. **Unused import**: Removed `PathBuf` from `source.rs` (it was imported but never used)
2. **`manual_repeat_n`**: Changed `std::iter::repeat(char).take(len)` to `std::iter::repeat_n(char, len)` in `diagnostics.rs`
3. **`approx_constant`**: Changed test value from `3.14` (approximate π) to `1.5` in `lexeme.rs`

### Bug fix
- Reordered `Severity` enum variants from `Error, Warning, Note` to `Note, Warning, Error`
- This fixes `test_severity_ordering` which expects `Error > Warning > Note`
- The derived `Ord` implementation gives earlier variants smaller values, so the most severe (Error) needs to be last
- Added documentation clarifying the ordering: "Note < Warning < Error (errors are most severe)"

## Testing
All 32 tests pass, and both `cargo fmt --check` and `cargo clippy -D warnings` now succeed.